### PR TITLE
feat: merge get options to single dict

### DIFF
--- a/src/senkalib/chain/bsc/bsc_transaction_generator.py
+++ b/src/senkalib/chain/bsc/bsc_transaction_generator.py
@@ -1,6 +1,6 @@
 from senkalib.chain.bsc.bsc_transaction import BscTransaction
 from senkalib.chain.transaction import Transaction 
-from senkalib.chain.transaction_generator import TransactionGenerator
+from senkalib.chain.transaction_generator import TransactionGenerator, GetOptions
 from senkalib.senka_setting import SenkaSetting
 from web3 import Web3
 from bscscan import BscScan
@@ -11,10 +11,10 @@ class BscTransactionGenerator(TransactionGenerator):
   chain = 'bsc'
 
   @classmethod
-  def get_transactions(cls, settings:SenkaSetting, address:str, timerange:dict = None, blockrange:dict = None) -> List[Transaction]:
+  def get_transactions(cls, settings:SenkaSetting, address:str, options:GetOptions = None) -> List[Transaction]:
     settings = settings.get_settings()
-    startblock = blockrange['startblock'] if blockrange is not None and 'startblock' in blockrange and type(blockrange['startblock']) is int else 0
-    endblock = blockrange['endblock'] if blockrange is not None and 'endblock' in blockrange and type(blockrange['endblock']) is int else 'latest'
+    startblock = options['startblock'] if options is not None and 'startblock' in options and type(options['startblock']) is int else 0
+    endblock = options['endblock'] if options is not None and 'endblock' in options and type(options['endblock']) is int else 'latest'
     w3 = Web3(Web3.HTTPProvider("https://bsc-dataseed.binance.org/"))
     transactions = []
     

--- a/src/senkalib/chain/kava/kava_transaction_generator.py
+++ b/src/senkalib/chain/kava/kava_transaction_generator.py
@@ -1,5 +1,5 @@
 from senkalib.chain.transaction import Transaction
-from senkalib.chain.transaction_generator import TransactionGenerator
+from senkalib.chain.transaction_generator import TransactionGenerator, GetOptions
 from senkalib.senka_setting import SenkaSetting
 from senkalib.chain.kava.kava_transaction import KavaTransaction
 from typing import List
@@ -9,11 +9,11 @@ class KavaTransactionGenerator(TransactionGenerator):
   chain = 'kava'
 
   @classmethod
-  def get_transactions(cls, settings:SenkaSetting, address:str, timerange:dict = None, blockrange:dict = None) -> List[Transaction]:
+  def get_transactions(cls, settings:SenkaSetting, address:str, options:GetOptions = None) -> List[Transaction]:
     osmosis_transactions = []
     num_transactions = 50
-    startblock = int(blockrange['startblock']) if blockrange is not None and 'startblock' in blockrange and type(blockrange['startblock']) is int else 0
-    endblock = int(blockrange['endblock']) if blockrange is not None and 'endblock' in blockrange and type(blockrange['endblock']) is int else None
+    startblock = int(options['startblock']) if options is not None and 'startblock' in options and type(options['startblock']) is int else 0
+    endblock = int(options['endblock']) if options is not None and 'endblock' in options and type(options['endblock']) is int else None
 
     while num_transactions >= 50:
       transactions = KavaTransactionGenerator.get_txs(address, startblock)

--- a/src/senkalib/chain/osmosis/osmosis_transaction_generator.py
+++ b/src/senkalib/chain/osmosis/osmosis_transaction_generator.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from dateutil import parser
 from operator import attrgetter
 from math import inf
-from senkalib.chain.transaction_generator import TransactionGenerator
+from senkalib.chain.transaction_generator import TransactionGenerator, GetOptions
 from senkalib.senka_setting import SenkaSetting
 from senkalib.chain.osmosis.osmosis_transaction import OsmosisTransaction
 from typing import List
@@ -12,11 +12,12 @@ class OsmosisTransactionGenerator(TransactionGenerator):
   chain = 'osmosis'
 
   @classmethod
-  def get_transactions(cls, settings:SenkaSetting, address:str, timerange:dict = None, blockrange:dict = None) -> List[OsmosisTransaction]:
-    startblock = int(blockrange['startblock']) if blockrange is not None and 'startblock' in blockrange and type(blockrange['startblock']) is int else 0
-    endblock = int(blockrange['endblock']) if blockrange is not None and 'endblock' in blockrange and type(blockrange['endblock']) is int else inf
-    starttime = int(timerange['starttime']) if timerange is not None and 'starttime' in timerange and type(timerange['starttime']) is int else 0
-    endtime = int(timerange['endtime']) if timerange is not None and 'endtime' in timerange and type(timerange['endtime']) is int else inf
+  def get_transactions(cls, settings:SenkaSetting, address:str, options:GetOptions = None) -> List[OsmosisTransaction]:
+    options = options if options is not None else {}
+    startblock = options.get('startblock', 0)
+    endblock = options.get('endblock', inf)
+    starttime = options.get('starttime', 0)
+    endtime = options.get('endtime', inf)
 
     total_result = []
     id_cursor = get_nearest_id(endtime)

--- a/src/senkalib/chain/transaction_generator.py
+++ b/src/senkalib/chain/transaction_generator.py
@@ -1,12 +1,18 @@
 from abc import ABCMeta, abstractmethod
 from senkalib.chain.transaction import Transaction 
 from senkalib.senka_setting import SenkaSetting
-from typing import List
+from typing import List, TypedDict
+
+class GetOptions(TypedDict, total=False):
+  startblock: int
+  endblock: int
+  starttime: int
+  endtime: int
 
 class TransactionGenerator(metaclass=ABCMeta):
   chain = None
 
   @classmethod
   @abstractmethod
-  def get_transactions(cls, settings:SenkaSetting, address:str, timerange:dict = None, blockrange:dict = None) -> List[Transaction]:
+  def get_transactions(cls, settings:SenkaSetting, address:str, options:GetOptions = None) -> List[Transaction]:
     pass

--- a/test/chain/bsc/test_bsc_transaction_generator.py
+++ b/test/chain/bsc/test_bsc_transaction_generator.py
@@ -15,7 +15,7 @@ class TestBscTransactionGenerator(unittest.TestCase):
     settings = SenkaSetting({})
     with patch.object(BscTransactionGenerator, 'get_txs', new=TestBscTransactionGenerator.mock_get_txs):
       with patch.object(Eth, 'get_transaction_receipt', new=TestBscTransactionGenerator.mock_get_transaction_receipt):
-        transactions = BscTransactionGenerator.get_transactions(settings, '0x0Dee38f987ca1EFE37da2cC39c6b2ace0A61A95A', None, {'startblock':13526335 ,'endblock':	14353208})
+        transactions = BscTransactionGenerator.get_transactions(settings, '0x0Dee38f987ca1EFE37da2cC39c6b2ace0A61A95A', {'startblock':13526335 ,'endblock':	14353208})
     timestamp = transactions[0].get_timestamp()
     fee = transactions[0].get_transaction_fee()
     transaction_receipt = transactions[0].get_transaction_receipt()

--- a/test/chain/kava/test_kava_transaction_generator.py
+++ b/test/chain/kava/test_kava_transaction_generator.py
@@ -13,14 +13,14 @@ class TestKavaTransactionGenerator(unittest.TestCase):
     settings = SenkaSetting({})
 
     with patch.object(KavaTransactionGenerator, 'get_txs', new=TestKavaTransactionGenerator.mock_get_txs):
-      transactions = KavaTransactionGenerator.get_transactions(settings, 'kava1af7lm2qv9zp526gjd3cdxrpr9zeangjlyhjqjx', None, {})
+      transactions = KavaTransactionGenerator.get_transactions(settings, 'kava1af7lm2qv9zp526gjd3cdxrpr9zeangjlyhjqjx', {})
       timestamp = transactions[0].get_timestamp()
       fee = transactions[0].get_transaction_fee()
       self.assertEqual(len(transactions), 31)
       self.assertEqual(timestamp, '2022-04-01 09:20:35')
       self.assertEqual(fee, Decimal(1000))
 
-      transactions = KavaTransactionGenerator.get_transactions(settings, 'kava1af7lm2qv9zp526gjd3cdxrpr9zeangjlyhjqjx', None, {'endblock': 4271593})
+      transactions = KavaTransactionGenerator.get_transactions(settings, 'kava1af7lm2qv9zp526gjd3cdxrpr9zeangjlyhjqjx', {'endblock': 4271593})
       self.assertEqual(len(transactions), 14)
 
   @classmethod

--- a/test/chain/osmosis/test_osmosis_transaction_generator.py
+++ b/test/chain/osmosis/test_osmosis_transaction_generator.py
@@ -15,21 +15,21 @@ class TestOsmosisTransactionGenerator(unittest.TestCase):
     settings = SenkaSetting({})
     # check results should be expected data
     get_txs.return_value = dummy_txs
-    txs = OsmosisTransactionGenerator.get_transactions(settings, 'address', None, {})
+    txs = OsmosisTransactionGenerator.get_transactions(settings, 'address')
     tx = txs[0]
     assert len(txs) == 44
     assert tx.get_timestamp() == '2022-01-15 12:18:55'
     assert tx.get_transaction_fee() == Decimal(33)
     # filter results by parameters
-    assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', None, {'startblock': 2781756})) == 43
-    assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', None, {'endblock': 2781756})) == 4
+    assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', {'startblock': 2781756})) == 43
+    assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', {'endblock': 2781756})) == 4
     assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', {'starttime': to_timestamp('2022-01-15T12:18:54Z')})) == 2
     assert len(OsmosisTransactionGenerator.get_transactions(settings, 'address', {'endtime': to_timestamp('2022-01-15T12:18:54Z')})) == 42
     # get_txs should be called multiply if result length gte 50
     get_txs.reset_mock()
     tx = dummy_txs[0]
     get_txs.side_effect = [list(repeat(tx, 50)), list(repeat(tx, 49))]
-    txs = OsmosisTransactionGenerator.get_transactions(settings, 'address', None, {})
+    txs = OsmosisTransactionGenerator.get_transactions(settings, 'address')
     assert len(txs) == 99
     assert get_txs.call_count == 2
 


### PR DESCRIPTION
TransactionGenerator.get_transactions の引数 timerange, blockrange を一つのdictとしてまとめた。
senka側ではtimerange, blockrangeをまだ利用している箇所がないため、この変更による影響は受けない。

CI結果
https://github.com/kouMatsumoto/senkalib/actions/runs/2206577965