### PR TITLE
fix: add newly required http headers for cosmostation api

### DIFF
--- a/src/senkalib/chain/osmosis/osmosis_transaction_generator.py
+++ b/src/senkalib/chain/osmosis/osmosis_transaction_generator.py
@@ -41,7 +41,10 @@ class OsmosisTransactionGenerator(TransactionGenerator):
 
   @classmethod
   def get_txs(cls, address: str, id_from: int) -> List[dict]:
-    return requests.get('https://api-osmosis.cosmostation.io/v1/account/new_txs/%s' % address, params={'from': id_from, 'limit': 50}).json()
+    params = {'from': id_from, 'limit': 50}
+    headers = {'Origin': 'https://www.mintscan.io', 'Referer': 'https://www.mintscan.io/'}  # workaround from 2022-04-25: both origin and referer headers are required
+
+    return requests.get('https://api-osmosis.cosmostation.io/v1/account/new_txs/%s' % address, params=params, headers=headers).json()
 
 
 @dataclass


### PR DESCRIPTION
cosmostaionのAPIがorigin, refererのヘッダーを要求するように変更されたため対応。
とりあえずosmosisのみ、kavaは後ほどまとめて対応する。

ローカルにて以下を動作確認済み
・header追加前はJSONデコードエラーが発生すること
・header追加後は正しくデータが取得できること

CI動作OK
https://github.com/kouMatsumoto/senkalib/actions/runs/2218508963