### PR TITLE
fix: use get method at bsc transaction generator params

### DIFF
--- a/src/senkalib/chain/bsc/bsc_transaction_generator.py
+++ b/src/senkalib/chain/bsc/bsc_transaction_generator.py
@@ -15,16 +15,8 @@ class BscTransactionGenerator(TransactionGenerator):
     @classmethod
     def get_transactions(cls, transaction_params: dict) -> List[Transaction]:
         settings_bsc = transaction_params["settings"].get_settings()
-        startblock = (
-            transaction_params["startblock"]
-            if transaction_params["startblock"] is not None
-            else 0
-        )
-        endblock = (
-            transaction_params["endblock"]
-            if transaction_params["endblock"] is not None
-            else None
-        )
+        startblock = transaction_params.get("startblock", 0),
+        endblock = transaction_params.get("endblock", None),
         w3 = Web3(Web3.HTTPProvider("https://bsc-dataseed.binance.org/"))
         transactions = []
 

--- a/test/chain/bsc/test_bsc_transaction_generator.py
+++ b/test/chain/bsc/test_bsc_transaction_generator.py
@@ -40,6 +40,21 @@ class TestBscTransactionGenerator(unittest.TestCase):
                 self.assertEqual(timestamp, "2021-12-28 01:30:55")
                 self.assertEqual(fee, 222150000000000)
 
+                # minimum_params
+                transaction_params = {
+                    "type": "address",
+                    "data": "0x0000000000000000000000000000000000000000",
+                    "settings": settings,
+                }
+                transactions = BscTransactionGenerator.get_transactions(
+                    transaction_params
+                )
+                timestamp = transactions[0].get_timestamp()
+                fee = transactions[0].get_transaction_fee()
+
+                self.assertEqual(timestamp, "2021-12-28 01:30:55")
+                self.assertEqual(fee, 222150000000000)
+
     @classmethod
     async def mock_get_txs(
         cls,


### PR DESCRIPTION
Make the process of acquiring transaction pramas the same as other Chains.

https://github.com/ca3-caaip/senkalib/blob/87fb3e6a03f55b4e50b6d8a4706198f9c68c3d18/src/senkalib/chain/osmosis/osmosis_transaction_generator.py#L25-L26