### PR TITLE
fix: token original table get all meta data

### DIFF
--- a/src/senkalib/token_original_id_table.py
+++ b/src/senkalib/token_original_id_table.py
@@ -19,8 +19,8 @@ class TokenOriginalIdTable:
     ) -> Union[dict, None]:
         object_token = list(
             filter(
-                lambda x: x["original_id"] == token_original_id
-                and x["platform"] == platform,
+                lambda x: x["original_id"].lower() == token_original_id.lower()
+                and x["platform"].lower() == platform.lower(),
                 self.token_original_id_table,
             )
         )
@@ -28,7 +28,7 @@ class TokenOriginalIdTable:
         if len(object_token) == 0:
             object_token = list(
                 filter(
-                    lambda x: x["original_id"] == token_original_id
+                    lambda x: x["original_id"].lower() == token_original_id.lower()
                     and "/" not in x["uti"],
                     self.token_original_id_table,
                 )

--- a/src/senkalib/token_original_id_table.py
+++ b/src/senkalib/token_original_id_table.py
@@ -43,12 +43,18 @@ class TokenOriginalIdTable:
         self,
         platform: str,
         token_original_id: str,
+        default_symbol: Union[str, None] = None,
     ) -> Union[str, None]:
         meta_data = self.get_all_meta_data(platform, token_original_id)
         if meta_data is not None:
             return meta_data["uti"]
         else:
-            return f"{urllib.parse.quote(token_original_id, safe='')}/{urllib.parse.quote(platform, safe='')}"
+            if default_symbol is not None:
+                return (
+                    f"{default_symbol}/{urllib.parse.quote(token_original_id, safe='')}"
+                )
+            else:
+                return f"{urllib.parse.quote(token_original_id, safe='')}"
 
     def get_symbol(
         self,

--- a/src/senkalib/token_original_id_table.py
+++ b/src/senkalib/token_original_id_table.py
@@ -35,7 +35,7 @@ class TokenOriginalIdTable:
             )
 
         token_symbol = None
-        if len(object_token) == 1:
+        if len(object_token) >= 1:
             token_symbol = object_token[0]
         return token_symbol
 

--- a/test/test_token_original_id_table.py
+++ b/test/test_token_original_id_table.py
@@ -27,6 +27,19 @@ class TestTokenOriginalIdTable(unittest.TestCase):
                     == "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
                 )
 
+                metadata = token_original_id_table.get_all_meta_data(
+                    "osmosis",
+                    "ibc/27394FB092D2ECCD56123C74F36e4C1F926001CEADA9CA97EA622b25F41E5EB2",
+                )
+                if metadata is None:
+                    assert False
+                assert metadata["uti"] == "atom"
+                assert metadata["platform"] == "osmosis"
+                assert (
+                    metadata["original_id"]
+                    == "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2"
+                )
+
     def test_get_uti_exist(self):
         with patch.object(requests, "get", new=TestTokenOriginalIdTable.mock_get):
             with patch.object(

--- a/test/test_token_original_id_table.py
+++ b/test/test_token_original_id_table.py
@@ -52,7 +52,7 @@ class TestTokenOriginalIdTable(unittest.TestCase):
                 )
                 assert uti == "atom"
 
-    def test_get_uti_nonexist(self):
+    def test_get_uti_nonexist_no_default_symbol(self):
         with patch.object(requests, "get", new=TestTokenOriginalIdTable.mock_get):
             with patch.object(
                 csv, "DictReader", new=TestTokenOriginalIdTable.mock_DictReader
@@ -62,7 +62,20 @@ class TestTokenOriginalIdTable(unittest.TestCase):
                     "osmosis",
                     "gamm/pool/497",
                 )
-                assert uti == "gamm%2Fpool%2F497/osmosis"
+                assert uti == "gamm%2Fpool%2F497"
+
+    def test_get_uti_nonexist_with_default_symbol(self):
+        with patch.object(requests, "get", new=TestTokenOriginalIdTable.mock_get):
+            with patch.object(
+                csv, "DictReader", new=TestTokenOriginalIdTable.mock_DictReader
+            ):
+                token_original_id_table = TokenOriginalIdTable("")
+                uti = token_original_id_table.get_uti(
+                    "osmosis",
+                    "ibc/noexist",
+                    "atomm",
+                )
+                assert uti == "atomm/ibc%2Fnoexist"
 
     def test_get_symbol(self):
         with patch.object(requests, "get", new=TestTokenOriginalIdTable.mock_get):

--- a/test/test_token_original_id_table.py
+++ b/test/test_token_original_id_table.py
@@ -133,6 +133,11 @@ class TestTokenOriginalIdTable(unittest.TestCase):
             },
             {
                 "uti": "osmo",
+                "platform": "kava",
+                "original_id": "osmo",
+            },
+            {
+                "uti": "osmo",
                 "platform": "osmosis",
                 "original_id": "osmo",
             },


### PR DESCRIPTION
def get_all_meta_data() がケースセンシティブなのでうまく期待通りにtoken_original_idからutiの取得ができないことがある。
必ずしも ケースセンシティブである必要はないのでケースインセンシティブにする

さらに、現状utiは該当するレコードがなかった場合常に 指定されたtoken_original_id/platformとしてたが外部からdefault_symbolとしてシンボル名を渡せるようにして、渡された場合は default_symbol/token_original_id となるようにする
